### PR TITLE
Reduce the Flatpak size

### DIFF
--- a/org.kde.kimagemapeditor.json
+++ b/org.kde.kimagemapeditor.json
@@ -14,6 +14,18 @@
         "--socket=wayland",
         "--system-talk-name=org.freedesktop.UDisks2"
     ],
+     "cleanup": [
+        "/include",
+        "/lib/cmake",
+        "/lib/pkgconfig",
+        "/share/doc",
+        "/share/qlogging-categories6",
+        "*.la",
+        "*.a"
+    ],
+    "cleanup-commands": [
+        "/app/cleanup-BaseApp.sh"
+    ],
     "modules": [
         {
             "name": "kimagemapeditor",


### PR DESCRIPTION
The installed size reduced from 304.9 MB to 296.9 MB MB.

KDE apps usually open an external website for help documentation.

Therefore, it's not required to keep the /share/doc folder.